### PR TITLE
Prevent dragging images

### DIFF
--- a/script.js
+++ b/script.js
@@ -82,6 +82,9 @@
             image.addEventListener('click', () => {
                 toggleBackground(image, index, 'imagesOutsideSkill');
             });
+            image.addEventListener('dragstart', (e) => {
+                e.preventDefault();
+            });
         });
 
         // Bind dark mode toggle event


### PR DESCRIPTION
Currently, clicking and starting a drag will end up not toggling the clicked image, instead of toggling it. This change blocks the dragstart event to ensure images cannot be dragged.

For what it's worth, I use this on https://github.com/Nightfirecat/zulrahguide for the same reason.