### PR TITLE
Fix dark mode flash of unstyled content

### DIFF
--- a/bare_bones.html
+++ b/bare_bones.html
@@ -14,6 +14,7 @@ the rest is standard HTML afaik.
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Ladlor's Interactive Progression Chart</title>
+    <script src="script.js" defer></script>
     <link rel="stylesheet" href="styles.css">
 
 </head>
@@ -286,7 +287,6 @@ the rest is standard HTML afaik.
     <footer>
         <p>Version 1.1.0 | <a href="changelog.html">View Changelog</a></p>
     </footer>
-    <script src="script.js" defer></script>
 </body>
 
 </html>

--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@ the rest is standard HTML afaik.
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Ladlor's Interactive Progression Chart</title>
+    <script src="script.js"></script>
     <link rel="stylesheet" href="styles.css">
     <script data-goatcounter="https://ladlor0interactive0prog.goatcounter.com/count"
     async src="//gc.zgo.at/count.js"></script>
@@ -340,8 +341,6 @@ the rest is standard HTML afaik.
             © 2013–2024 Jagex Ltd. All rights reserved.
         </p>
     </footer>
-    
-    <script src="script.js" defer></script>
 </body>
 
 </html>


### PR DESCRIPTION
Fixes #10

This change moves all the JS inside `<head>` and removes the `defer` property to ensure it is fully loaded before the page loads and is displayed. Per my comments in the issue, I'd be happy to split out the dark mode load behavior if desired, but the page's JS is quite light and has very little impact on load times, so I think that would be excessive.

This change can be tested at https://nightfirecat.github.io/InteractiveGearProg/