### PR TITLE
Adds skip feature to right click menu

### DIFF
--- a/scripts/render-items-bare-bones.js
+++ b/scripts/render-items-bare-bones.js
@@ -168,8 +168,14 @@ async function loadChart() {
  */
 function saveNodeState(node) {
     let savedStates = JSON.parse(localStorage.getItem("sharedNodeStates")) || {}; // Use shared storage key
-    savedStates[node.id] = node.classList.contains("green-background");
+    savedStates[node.id] = parseInt(node.dataset.state);
     localStorage.setItem("sharedNodeStates", JSON.stringify(savedStates)); // Store under shared key
+}
+
+function updateNodeVisualState(node) {
+    node.classList.remove("state-0", "state-1", "state-2");
+    let state = parseInt(node.dataset.state);
+    node.classList.add(`state-${state}`);
 }
 
 function initializeNodeStates() {
@@ -181,14 +187,20 @@ function initializeNodeStates() {
     chartContainer.addEventListener("click", (event) => {
         let node = event.target.closest(".node");
         if (!node) return;
-        node.classList.toggle("green-background");
+
+        let currentState = parseInt(node.dataset.state) || 0;
+        let nextState = currentState === 1 ? 0 : 1;
+        node.dataset.state = nextState;
+
+        updateNodeVisualState(node);
         saveNodeState(node); // Save state under shared key
     });
 
     for (let nodeId in savedStates) {
         let node = document.getElementById(nodeId);
-        if (node && savedStates[nodeId]) {
-            node.classList.add("green-background");
+        if (node) {
+            node.dataset.state = savedStates[nodeId];
+            updateNodeVisualState(node);
         }
     }
 }

--- a/scripts/render-items.js
+++ b/scripts/render-items.js
@@ -166,8 +166,14 @@ async function loadChart() {
  */
 function saveNodeState(node) {
     let savedStates = JSON.parse(localStorage.getItem("sharedNodeStates")) || {}; // Use shared storage key
-    savedStates[node.id] = node.classList.contains("green-background");
+    savedStates[node.id] = parseInt(node.dataset.state);
     localStorage.setItem("sharedNodeStates", JSON.stringify(savedStates)); // Store under shared key
+}
+
+function updateNodeVisualState(node) {
+    node.classList.remove("state-0", "state-1", "state-2");
+    let state = parseInt(node.dataset.state);
+    node.classList.add(`state-${state}`);
 }
 
 function initializeNodeStates() {
@@ -179,14 +185,20 @@ function initializeNodeStates() {
     chartContainer.addEventListener("click", (event) => {
         let node = event.target.closest(".node");
         if (!node) return;
-        node.classList.toggle("green-background");
+
+        let currentState = parseInt(node.dataset.state) || 0;
+        let nextState = currentState === 1 ? 0 : 1;
+        node.dataset.state = nextState;
+
+        updateNodeVisualState(node);
         saveNodeState(node); // Save state under shared key
     });
 
     for (let nodeId in savedStates) {
         let node = document.getElementById(nodeId);
-        if (node && savedStates[nodeId]) {
-            node.classList.add("green-background");
+        if (node) {
+            node.dataset.state = savedStates[nodeId];
+            updateNodeVisualState(node);
         }
     }
 }

--- a/scripts/right-clicks.js
+++ b/scripts/right-clicks.js
@@ -13,6 +13,7 @@ document.addEventListener("DOMContentLoaded", () => {
     buttonContainer.id = "button-container";
 
     let wikiButton = initializeWikiButton(buttonContainer);
+    let skipButton = initializeSkipButton(buttonContainer);
     let cancelButton = initializeCancelButton(buttonContainer);
 
     // Append to menu and body
@@ -38,6 +39,25 @@ document.addEventListener("DOMContentLoaded", () => {
             };
         } else {
             wikiButton.style.display = "none";
+        }
+        
+        // Configure Skip Button
+        skipButton.onclick = () => {
+            const currentState = parseInt(node.dataset.state);
+
+            if (currentState === 2 && node.dataset.prevState !== undefined) {
+                // Restore previous state
+                node.dataset.state = node.dataset.prevState;
+                delete node.dataset.prevState;
+            } else {
+                // Save current state and mark as skipped
+                node.dataset.prevState = currentState;
+                node.dataset.state = 2;
+            }
+        
+            contextMenu.style.display = "none";
+            updateNodeVisualState(node);
+            saveNodeState(node);
         }
 
         // Configure Cancel Button
@@ -86,6 +106,25 @@ function initializeWikiButton(buttonContainer) {
     wikiButton.appendChild(orangeText);
     buttonContainer.appendChild(wikiButton);
     return wikiButton;
+}
+
+function initializeSkipButton(buttonContainer) {
+    const skipButton = document.createElement("button");
+    skipButton.id = "skip-button";
+    skipButton.classList.add("menu-button");
+
+    const whiteText = document.createElement("span");
+    whiteText.classList.add("left-text");
+    whiteText.textContent = "Mark as ";
+
+    const orangeText = document.createElement("span");
+    orangeText.classList.add("right-text");
+    orangeText.textContent = "Skipped";
+
+    skipButton.appendChild(whiteText);
+    skipButton.appendChild(orangeText);
+    buttonContainer.appendChild(skipButton);
+    return skipButton;
 }
 
 function initializeCancelButton(buttonContainer) {

--- a/styles/right-clicks.css
+++ b/styles/right-clicks.css
@@ -55,6 +55,7 @@
     text-align: left;
     text-shadow: 1px 1px 2px black;
     /* Adds a slight dark shadow */
+    white-space: pre;
 }
 
 .right-text {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -1,4 +1,5 @@
 :root {
+    --transparent: rgb(0, 0, 0, 0);
     --background-color: #555555;
     --green-complete: rgb(0, 200, 0);
 
@@ -105,9 +106,30 @@ ul {
     font-size: 0.8rem;
 }
 
-/* Green background class for toggled elements */
-.green-background {
-    background-color: rgb(0, 200, 0);
+/* 
+    Individual item states where:
+        state-0 = incomplete
+        state-1 = complete
+        state-2 = skipped
+*/
+.state-0 { background-color: var(--transparent); }
+.state-1 { background-color: var(--green-complete); }
+.state-2 {
+    background-color: var(--green-complete);
+    position: relative;     /* required for pseudo-element positioning */
+}
+  
+/* Add top-right triangle using a pseudo-element for skipped state */
+.state-2::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: 0;
+    height: 0;
+    border-style: solid;
+    border-width: 0 10px 10px 0; /* triangle shape */
+    border-color: transparent yellow transparent transparent;
 }
 
 .chart>.arrow {
@@ -139,11 +161,6 @@ body .chart>img {
 body .arrow {
     color: #e0e0e0;
     /* Softer light arrow color */
-}
-
-body .green-background {
-    background-color: #008000;
-    /* Brightened green for better visibility */
 }
 
 /* Style for the dark mode toggle button in dark mode */


### PR DESCRIPTION
Overview
- This update enhances how progression points are handled by introducing a third state "skipped", in addition to the existing "incomplete" and "complete" states.

Motivation
- Some players prefer to bypass certain early-game progression points and move directly to their later or more powerful counterparts.
- With new game updates, early-game items may be introduced after an account has already progressed beyond them.
- Previously, users would mark such items as "complete" in Ladlor's Chart, which made it hard to distinguish between truly completed items and those intentionally skipped.

Implementation
- Refactored the progression point logic to support three distinct states:
    - incomplete
    - skipped
    - complete
- This makes it clearer which items were deliberately skipped and allows for better decision-making if a user wants to revisit a skipped item.
- The new structure is future-proof, allowing easy addition of more states later (e.g., "restricted" for pure builds).